### PR TITLE
Legger til feilhåndtering ved mottak av Vedtaksmelding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ sonarqube {
         property("sonar.organization", "navit")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.login", System.getenv("SONAR_TOKEN"))
-        property("sonar.exclusions", "**/Koin*")
+        property("sonar.exclusions", "**/Koin*,**Mock**")
     }
 }
 
@@ -46,7 +46,7 @@ tasks.jacocoTestReport {
 tasks.withType<JacocoReport> {
     classDirectories.setFrom(
             sourceSets.main.get().output.asFileTree.matching {
-                exclude("**/Koin**", "**/AppKt**")
+                exclude("**/Koin**", "**/App**", "**Mock**")
             }
     )
 }

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/MockFailedVedtaksmeldingsRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/MockFailedVedtaksmeldingsRepository.kt
@@ -1,0 +1,18 @@
+package no.nav.helse.spion.vedtaksmelding
+
+import java.util.*
+
+class MockFailedVedtaksmeldingsRepository : FailedVedtaksmeldingRepository {
+    private val list = mutableListOf<FailedVedtaksmelding>()
+    override fun save(message: FailedVedtaksmelding) {
+        list.add(message)
+    }
+
+    override fun getNextFailedMessages(numberToGet: Int): Collection<FailedVedtaksmelding> {
+        return list
+    }
+
+    override fun delete(id: UUID) {
+        list.removeIf { it.id == id }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/Vedtaksmelding.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/Vedtaksmelding.kt
@@ -1,10 +1,6 @@
 package no.nav.helse.spion.vedtaksmelding
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
-import org.apache.kafka.common.serialization.Deserializer
-import org.apache.kafka.common.serialization.Serializer
 import java.time.LocalDate
 
 enum class VedtaksmeldingsYtelse { SP, FP, SVP, PP, OP, OM }
@@ -32,25 +28,3 @@ data class Vedtaksmelding(
         val maksDato: LocalDate?
 
 )
-
-internal abstract class SerDes<V>(protected val om: ObjectMapper) : Serializer<V>, Deserializer<V> {
-    override fun serialize(topic: String?, data: V): ByteArray? {
-        return data?.let {
-            om.writeValueAsBytes(it)
-        }
-    }
-
-    override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) { /* objectmapperen er allerde konfigurert*/
-    }
-
-    override fun close() { /* ikke nødvending for jackson */
-    }
-}
-
-internal class VedtaksMeldingSerDes(om: ObjectMapper) : SerDes<Vedtaksmelding>(om) {
-    override fun deserialize(topic: String?, data: ByteArray?): Vedtaksmelding? {
-        return data?.let {
-            om.readValue<Vedtaksmelding>(it)
-        }
-    }
-}

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/Vedtaksmelding.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/Vedtaksmelding.kt
@@ -1,4 +1,4 @@
-package no.nav.helse.spion.kafka
+package no.nav.helse.spion.vedtaksmelding
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingClient.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingClient.kt
@@ -1,6 +1,5 @@
 package no.nav.helse.spion.vedtaksmelding
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.helse.spion.selfcheck.HealthCheck
 import no.nav.helse.spion.selfcheck.HealthCheckType
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -14,7 +13,7 @@ interface KafkaMessageProvider {
     fun confirmProcessingDone()
 }
 
-class VedtaksmeldingClient(props: Map<String, Any>, topicName: String, om: ObjectMapper) : KafkaMessageProvider, HealthCheck {
+class VedtaksmeldingClient(props: Map<String, Any>, topicName: String) : KafkaMessageProvider, HealthCheck {
     private val consumer = KafkaConsumer<String, String>(props.apply { }, StringDeserializer(), StringDeserializer())
     override val healthCheckType = HealthCheckType.ALIVENESS
 

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
@@ -1,0 +1,16 @@
+package no.nav.helse.spion.vedtaksmelding
+
+import java.util.*
+
+data class FailedVedtaksmelding(
+        val melding: String,
+        val errorMessage: String?,
+        val id: UUID = UUID.randomUUID()
+)
+
+interface FailedVedtaksmeldingRepository {
+    fun save(message: FailedVedtaksmelding)
+    fun getNextFailedMessages(numberToGet: Int): Collection<FailedVedtaksmelding>
+    fun delete(id: UUID)
+}
+

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
@@ -1,4 +1,4 @@
-package no.nav.helse.spion.kafka
+package no.nav.helse.spion.vedtaksmelding
 
 import com.github.javafaker.Faker
 import no.nav.helse.spion.domene.Arbeidsgiver

--- a/src/main/kotlin/no/nav/helse/spion/web/App.kt
+++ b/src/main/kotlin/no/nav/helse/spion/web/App.kt
@@ -19,8 +19,8 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.util.KtorExperimentalAPI
 import no.nav.helse.spion.auth.localCookieDispenser
-import no.nav.helse.spion.kafka.VedtaksmeldingProcessor
 import no.nav.helse.spion.nais.nais
+import no.nav.helse.spion.vedtaksmelding.VedtaksmeldingProcessor
 import no.nav.helse.spion.web.api.spion
 import no.nav.security.token.support.ktor.tokenValidationSupport
 import org.koin.ktor.ext.Koin

--- a/src/test/kotlin/no/nav/helse/slowtests/kafka/VedtaksmeldingClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/kafka/VedtaksmeldingClientTest.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.slowtests.kafka
 
-import no.nav.helse.spion.kafka.*
+import no.nav.helse.spion.vedtaksmelding.*
 import no.nav.helse.spion.web.common
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.KafkaAdminClient


### PR DESCRIPTION
* gjorde kafkaklienten til en "string"-klient for å ha kontroll på de-serialiseringen
* La til en type og et repo-interface for å holde og lagre feil
* La til logikk i processoren som lagrer melding ved feil i prossesringen