### PR TITLE
Bruk arbeidsgiverid i stedet for virknr/idnr

### DIFF
--- a/src/main/kotlin/no/nav/helse/spion/domene/Arbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/Arbeidsgiver.kt
@@ -3,6 +3,5 @@ package no.nav.helse.spion.domene
 data class Arbeidsgiver(
         val navn: String,
         val organisasjonsnummer: String?,
-        val virksomhetsnummer: String?,
-        val identitetsnummer: String?
+        val arbeidsgiverId: String
 )

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/MockYtelsesperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/MockYtelsesperiodeRepository.kt
@@ -15,7 +15,7 @@ class MockYtelsesperiodeRepository : YtelsesperiodeRepository {
             arbeidsforhold = Arbeidsforhold(
                     arbeidsforholdId = "1",
                     arbeidstaker = Person("Solan", "Gundersen", "10987654321"),
-                    arbeidsgiver = Arbeidsgiver("Flåklypa Verksted", "666666666", "555555555", null)
+                    arbeidsgiver = Arbeidsgiver("Flåklypa Verksted", "666666666", "555555555")
             ),
             vedtaksId = "1",
             refusjonsbeløp = BigDecimal(10000),
@@ -47,8 +47,8 @@ class MockYtelsesperiodeRepository : YtelsesperiodeRepository {
 
     override fun hentArbeidsgivere(identitetsnummer: String): List<Arbeidsgiver> {
         return listOf(
-                Arbeidsgiver("Etterretningstjenesten", "1965", "0", null),
-                Arbeidsgiver("Secret Intelligence Service", "MI6", "1", null)
+                Arbeidsgiver("Etterretningstjenesten", "1965", "0"),
+                Arbeidsgiver("Secret Intelligence Service", "MI6", "1")
         )
     }
 }

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/PostgresRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/PostgresRepository.kt
@@ -16,7 +16,7 @@ class PostgresRepository(val ds: DataSource, val mapper: ObjectMapper) : Ytelses
         ds.connection.use { con ->
             val sql = """SELECT ytelsesperiode::json FROM spiondata 
             WHERE ytelsesperiode -> 'arbeidsforhold' -> 'arbeidstaker' ->> 'identitetsnummer' = ?
-            AND ytelsesperiode -> 'arbeidsforhold' -> 'arbeidsgiver' ->> 'virksomhetsnummer' = ?;"""
+            AND ytelsesperiode -> 'arbeidsforhold' -> 'arbeidsgiver' ->> 'arbeidsgiverId' = ?;"""
 
             val res = con.prepareStatement(sql).apply{
                 setString(1, identitetsnummer)
@@ -47,12 +47,12 @@ class PostgresRepository(val ds: DataSource, val mapper: ObjectMapper) : Ytelses
         ds.connection.use { con ->
             val sql = """DELETE  FROM spiondata 
          WHERE ytelsesperiode -> 'arbeidsforhold' -> 'arbeidstaker' ->> 'identitetsnummer' = ?
-            AND ytelsesperiode -> 'arbeidsforhold' -> 'arbeidsgiver' ->> 'virksomhetsnummer' = ?
+            AND ytelsesperiode -> 'arbeidsforhold' -> 'arbeidsgiver' ->> 'arbeidsgiverId' = ?
             AND ytelsesperiode -> 'periode' ->> 'fom' = ?
             AND ytelsesperiode -> 'periode' ->> 'tom' = ?;"""
             val deletedCount = con.prepareStatement(sql).apply {
                 setString(1, periode.arbeidsforhold.arbeidstaker.identitetsnummer)
-                setString(2, periode.arbeidsforhold.arbeidsgiver.virksomhetsnummer)
+                setString(2, periode.arbeidsforhold.arbeidsgiver.arbeidsgiverId)
                 setString(3, periode.periode.fom.toString())
                 setString(4, periode.periode.tom.toString())
             }.executeUpdate()

--- a/src/main/kotlin/no/nav/helse/spion/domenetjenester/SpionService.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domenetjenester/SpionService.kt
@@ -7,7 +7,7 @@ import no.nav.helse.spion.domene.AltinnOrganisasjon
 
 class SpionService(private val sakRepo: YtelsesperiodeRepository, private val authRepo: AuthorizationsRepository) {
 
-    fun hentYtelserForPerson(identitetsnummer: String, virksomhetsnummer: String, arbeidsgiverIdentitetsnummer: String?): List<Ytelsesperiode> {
+    fun hentYtelserForPerson(identitetsnummer: String, virksomhetsnummer: String): List<Ytelsesperiode> {
         return sakRepo.hentYtelserForPerson(identitetsnummer, virksomhetsnummer)
     }
     fun hentArbeidsgivere(identitet: String) : Set<AltinnOrganisasjon> {

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessor.kt
@@ -85,7 +85,7 @@ fun mapVedtaksMeldingTilYtelsesPeriode(vm: Vedtaksmelding): Ytelsesperiode {
             Periode(vm.fom, vm.tom),
             Arbeidsforhold("",
                     Person(vm.fornavn, vm.etternavn, vm.identitetsNummer),
-                    Arbeidsgiver("TODO?", "TODO?", vm.virksomhetsnummer, null)),
+                    Arbeidsgiver("TODO?", "TODO?", vm.virksomhetsnummer)),
             "UKJENT",
             vm.refusjonsbeløp?.toBigDecimal(),
             vm.status.correspondingDomainStatus,

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
@@ -18,8 +18,7 @@ private class ArbeidsgiverGenerator(private val maxUniqueArbeidsgivere: Int = 10
             val arbeidsGiver = Arbeidsgiver(
                     faker.funnyName().name(),
                     Random.Default.nextLong(111111111, 999999999).toString(),
-                    Random.Default.nextLong(111111111, 999999999).toString(),
-                    null
+                    Random.Default.nextLong(111111111, 999999999).toString()
             )
             arbeidsgivere.add(arbeidsGiver)
             arbeidsGiver
@@ -82,7 +81,7 @@ class VedtaksmeldingGenerator(
 
         return Vedtaksmelding(
                 person.identitetsnummer,
-                arbeidsgiverGenerator.getRandomArbeidsGiver().virksomhetsnummer!!,
+                arbeidsgiverGenerator.getRandomArbeidsGiver().arbeidsgiverId!!,
                 status,
                 periode.fom,
                 periode.tom,

--- a/src/main/kotlin/no/nav/helse/spion/web/api/SpionRoute.kt
+++ b/src/main/kotlin/no/nav/helse/spion/web/api/SpionRoute.kt
@@ -32,7 +32,7 @@ fun Route.spion(service: SpionService, authorizer: Authorizer) {
 
             post("/oppslag") {
                 val oppslag = call.receive<OppslagDto>()
-                call.respond(service.hentYtelserForPerson(oppslag.identitetsnummer, oppslag.arbeidsgiverOrgnr, oppslag.arbeidsgiverIdentitetsnummer))
+                call.respond(service.hentYtelserForPerson(oppslag.identitetsnummer, oppslag.arbeidsgiverId))
             }
         }
         route("/arbeidsgivere") {

--- a/src/main/kotlin/no/nav/helse/spion/web/dto/OppslagDto.kt
+++ b/src/main/kotlin/no/nav/helse/spion/web/dto/OppslagDto.kt
@@ -3,5 +3,5 @@ package no.nav.helse.spion.web.dto
 data class OppslagDto (
     val identitetsnummer: String,
     val arbeidsgiverOrgnr: String,
-    val arbeidsgiverIdentitetsnummer: String?
+    val arbeidsgiverId: String
 )

--- a/src/test/kotlin/no/nav/helse/YtelsesperiodeGenerator.kt
+++ b/src/test/kotlin/no/nav/helse/YtelsesperiodeGenerator.kt
@@ -21,8 +21,7 @@ private class ArbeidsgiverGenerator(private val maxUniqueArbeidsgivere: Int = 10
             val arbeidsGiver = Arbeidsgiver(
                     faker.funnyName().name(),
                     Random.Default.nextLong(111111111, 999999999).toString(),
-                    Random.Default.nextLong(111111111, 999999999).toString(),
-                    null
+                    Random.Default.nextLong(111111111, 999999999).toString()
             )
             arbeidsgivere.add(arbeidsGiver)
             arbeidsGiver

--- a/src/test/kotlin/no/nav/helse/slowtests/db/integration/DatabaseTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/integration/DatabaseTests.kt
@@ -29,7 +29,7 @@ internal class postgresTests : KoinComponent {
             arbeidsforhold = Arbeidsforhold(
                     arbeidsforholdId = "1",
                     arbeidstaker = Person("Solan", "Gundersen", "10987654321"),
-                    arbeidsgiver = Arbeidsgiver("Flåklypa Verksted", "666666666", "555555555", null)
+                    arbeidsgiver = Arbeidsgiver("Flåklypa Verksted", "666666666", "555555555")
             ),
             vedtaksId = "1",
             refusjonsbeløp = BigDecimal(10000),

--- a/src/test/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessorTests.kt
+++ b/src/test/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessorTests.kt
@@ -121,7 +121,7 @@ class VedtaksmeldingMappingTests {
             assertEquals(melding.etternavn, yp.arbeidsforhold.arbeidstaker.etternavn)
             assertEquals(melding.identitetsNummer, yp.arbeidsforhold.arbeidstaker.identitetsnummer)
 
-            assertEquals(melding.virksomhetsnummer, yp.arbeidsforhold.arbeidsgiver.virksomhetsnummer)
+            assertEquals(melding.virksomhetsnummer, yp.arbeidsforhold.arbeidsgiver.arbeidsgiverId)
 
             assertEquals(melding.refusjonsbeløp?.toBigDecimal(), yp.refusjonsbeløp)
             assertEquals(melding.dagsats?.toBigDecimal(), yp.dagsats)

--- a/src/test/kotlin/no/nav/helse/spion/web/integration/AuthenticationTests.kt
+++ b/src/test/kotlin/no/nav/helse/spion/web/integration/AuthenticationTests.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertNotEquals
 
 class ApplicationAuthenticationTest : ControllerIntegrationTestBase() {
 
-    val oppslag = OppslagDto("200150015432", "987654321", null)
+    val oppslag = OppslagDto("200150015432", "987654321", "987654321")
 
     @Test
     fun `saksOppslag with Missing JWT returns 401 Unauthorized`() {

--- a/src/test/kotlin/no/nav/helse/spion/web/integration/AuthorizationTests.kt
+++ b/src/test/kotlin/no/nav/helse/spion/web/integration/AuthorizationTests.kt
@@ -23,8 +23,8 @@ import kotlin.test.assertNotEquals
 
 class ApplicationAuthorizationTest : ControllerIntegrationTestBase() {
 
-    val noAccessToThisOrg = OppslagDto("200150015432", "123456789", null)
-    val hasAccessToThisOrg  = OppslagDto("200150015432", "910020102", null)
+    val noAccessToThisOrg = OppslagDto("200150015432", "123456789", "123456789")
+    val hasAccessToThisOrg  = OppslagDto("200150015432", "910020102", "123456789")
 
     @Test
     fun `saksOppslag when logged in but unauthorized for the given Virksomhet returns 403 Forbidden`() {


### PR DESCRIPTION
Bytter ut konseptet at vi kan ha enten virksomhetsnummer eller identitetsnummer for arbeidsgiver til å kun støtte virksomhetsnummer. Det er forvirrende at vi har en valgfri variabel som vi egentlig ikke skal bruke enda rundt omkring i koden, og i oppslagsDto bør vi alltid få både organisasjonsnummer og virksomhetsnummer inntil videre. Gir feltet virksomhetsnummer navnet 'arbeidsgiverid' i stedet i dokumentdatabasen, så kan vi utvide til å støtte å lagre identitetsnummeret til arbeidsgiveren likt når vi skal utvide modellen! Det forenkler indeksering og constraints :) 