### PR TITLE
Postgresrepo for failed messages

### DIFF
--- a/docker/local/postgres/initdb.sh
+++ b/docker/local/postgres/initdb.sh
@@ -16,7 +16,7 @@ psql -v ON_ERROR_STOP=1 --username "spion" --dbname "spion" <<-EOSQL
     CREATE INDEX arbeidstaker ON spiondata ((ytelsesperiode ->'arbeidsforhold'-> 'arbeidstaker' ->> 'identitetsnummer'));
     CREATE INDEX orgnr ON spiondata ((ytelsesperiode ->'arbeidsforhold'-> 'arbeidsgiver' ->> 'organisasjonsnummer'));
 
-    CREATE TABLE failedvedaksmelding (
+    CREATE TABLE failedvedtaksmelding (
         messageData jsonb NOT NULL,
         errorMessage text,
         id uuid NOT NULL

--- a/docker/local/postgres/initdb.sh
+++ b/docker/local/postgres/initdb.sh
@@ -16,4 +16,10 @@ psql -v ON_ERROR_STOP=1 --username "spion" --dbname "spion" <<-EOSQL
     CREATE INDEX arbeidstaker ON spiondata ((ytelsesperiode ->'arbeidsforhold'-> 'arbeidstaker' ->> 'identitetsnummer'));
     CREATE INDEX orgnr ON spiondata ((ytelsesperiode ->'arbeidsforhold'-> 'arbeidsgiver' ->> 'organisasjonsnummer'));
 
+    CREATE TABLE failedvedaksmelding (
+        messageData jsonb NOT NULL,
+        errorMessage text,
+        id uuid NOT NULL
+    );
+
 EOSQL

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/MockYtelsesperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/MockYtelsesperiodeRepository.kt
@@ -44,11 +44,4 @@ class MockYtelsesperiodeRepository : YtelsesperiodeRepository {
     override fun save(yp: Ytelsesperiode) {
         println("saving $yp")
     }
-
-    override fun hentArbeidsgivere(identitetsnummer: String): List<Arbeidsgiver> {
-        return listOf(
-                Arbeidsgiver("Etterretningstjenesten", "1965", "0"),
-                Arbeidsgiver("Secret Intelligence Service", "MI6", "1")
-        )
-    }
 }

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/PostgresRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/PostgresRepository.kt
@@ -2,15 +2,10 @@ package no.nav.helse.spion.domene.ytelsesperiode.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.helse.spion.domene.Arbeidsgiver
 import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
 import javax.sql.DataSource
 
 class PostgresRepository(val ds: DataSource, val mapper: ObjectMapper) : YtelsesperiodeRepository {
-
-    override fun hentArbeidsgivere(identitetsnummer: String): List<Arbeidsgiver> {
-        TODO("not implemented")
-    }
 
     override fun hentYtelserForPerson(identitetsnummer: String, virksomhetsnummer: String): List<Ytelsesperiode> {
         ds.connection.use { con ->

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/YtelsesperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/repository/YtelsesperiodeRepository.kt
@@ -1,10 +1,8 @@
 package no.nav.helse.spion.domene.ytelsesperiode.repository
 
-import no.nav.helse.spion.domene.Arbeidsgiver
 import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
 
 interface YtelsesperiodeRepository {
-    fun hentArbeidsgivere(identitetsnummer: String) : List<Arbeidsgiver>
     fun hentYtelserForPerson(identitetsnummer: String, virksomhetsnummer: String) : List<Ytelsesperiode>
     fun save(yp: Ytelsesperiode)
 }

--- a/src/main/kotlin/no/nav/helse/spion/domenetjenester/SpionService.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domenetjenester/SpionService.kt
@@ -1,16 +1,17 @@
 package no.nav.helse.spion.domenetjenester
 
-import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
-import no.nav.helse.spion.domene.ytelsesperiode.repository.YtelsesperiodeRepository
 import no.nav.helse.spion.auth.AuthorizationsRepository
 import no.nav.helse.spion.domene.AltinnOrganisasjon
+import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
+import no.nav.helse.spion.domene.ytelsesperiode.repository.YtelsesperiodeRepository
 
 class SpionService(private val sakRepo: YtelsesperiodeRepository, private val authRepo: AuthorizationsRepository) {
 
     fun hentYtelserForPerson(identitetsnummer: String, virksomhetsnummer: String): List<Ytelsesperiode> {
         return sakRepo.hentYtelserForPerson(identitetsnummer, virksomhetsnummer)
     }
-    fun hentArbeidsgivere(identitet: String) : Set<AltinnOrganisasjon> {
+
+    fun hentArbeidsgivere(identitet: String): Set<AltinnOrganisasjon> {
         return authRepo.hentOrgMedRettigheterForPerson(identitet)
     }
 }

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
@@ -1,9 +1,10 @@
 package no.nav.helse.spion.vedtaksmelding
 
 import java.util.*
+import javax.sql.DataSource
 
 data class FailedVedtaksmelding(
-        val melding: String,
+        val messageData: String,
         val errorMessage: String?,
         val id: UUID = UUID.randomUUID()
 )
@@ -14,3 +15,46 @@ interface FailedVedtaksmeldingRepository {
     fun delete(id: UUID)
 }
 
+class PostgresFailedVedtaksmeldingRepository(val dataSource: DataSource) : FailedVedtaksmeldingRepository {
+    private val tableName = "failedvedaksmelding"
+
+    private val insertStatement = "INSERT INTO $tableName(messageData, errorMessage, id) VALUES(?, ?, ?)"
+    private val getStatement = "SELECT * FROM $tableName"
+    private val deleteStatement = "DELETE FROM $tableName WHERE id = ?"
+
+    override fun save(message: FailedVedtaksmelding) {
+        dataSource.connection.use {
+            it.prepareStatement(insertStatement).apply {
+                setString(1, message.messageData)
+                setString(2, message.errorMessage)
+                setString(3, message.id.toString())
+            }.executeUpdate()
+        }
+    }
+
+    override fun getNextFailedMessages(numberToGet: Int): Collection<FailedVedtaksmelding> {
+        dataSource.connection.use {
+            val res = it.prepareStatement(getStatement + " LIMIT $numberToGet")
+                    .executeQuery()
+
+            val resultatListe = mutableListOf<FailedVedtaksmelding>()
+
+            while (res.next()) {
+                resultatListe.add(FailedVedtaksmelding(
+                        res.getString("messageData"),
+                        res.getString("errorMessage"),
+                        UUID.fromString(res.getString("id"))
+                ))
+            }
+            return resultatListe
+        }
+    }
+
+    override fun delete(id: UUID) {
+        dataSource.connection.use {
+            it.prepareStatement(deleteStatement).apply {
+                setString(1, id.toString())
+            }.executeUpdate()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
@@ -18,9 +18,9 @@ interface FailedVedtaksmeldingRepository {
 class PostgresFailedVedtaksmeldingRepository(val dataSource: DataSource) : FailedVedtaksmeldingRepository {
     private val tableName = "failedvedaksmelding"
 
-    private val insertStatement = "INSERT INTO $tableName(messageData, errorMessage, id) VALUES(?, ?, ?)"
+    private val insertStatement = "INSERT INTO $tableName(messageData, errorMessage, id) VALUES(?::json, ?, ?::uuid)"
     private val getStatement = "SELECT * FROM $tableName"
-    private val deleteStatement = "DELETE FROM $tableName WHERE id = ?"
+    private val deleteStatement = "DELETE FROM $tableName WHERE id = ?::uuid"
 
     override fun save(message: FailedVedtaksmelding) {
         dataSource.connection.use {

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingErrorHandling.kt
@@ -16,7 +16,7 @@ interface FailedVedtaksmeldingRepository {
 }
 
 class PostgresFailedVedtaksmeldingRepository(val dataSource: DataSource) : FailedVedtaksmeldingRepository {
-    private val tableName = "failedvedaksmelding"
+    private val tableName = "failedvedtaksmelding"
 
     private val insertStatement = "INSERT INTO $tableName(messageData, errorMessage, id) VALUES(?::json, ?, ?::uuid)"
     private val getStatement = "SELECT * FROM $tableName"

--- a/src/test/kotlin/no/nav/helse/slowtests/db/PostgresFailedVedtaksmeldingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/PostgresFailedVedtaksmeldingRepositoryTest.kt
@@ -1,0 +1,40 @@
+package no.nav.helse.slowtests.db
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.helse.spion.db.createLocalHikariConfig
+import no.nav.helse.spion.vedtaksmelding.FailedVedtaksmelding
+import no.nav.helse.spion.vedtaksmelding.PostgresFailedVedtaksmeldingRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PostgresFailedVedtaksmeldingRepositoryTest {
+
+    lateinit var repo: PostgresFailedVedtaksmeldingRepository
+    lateinit var dataSource: HikariDataSource
+
+    private val failedVedtaksmelding = FailedVedtaksmelding("""{"test": "test"}""", "test")
+
+    @BeforeEach
+    internal fun setUp() {
+        dataSource = HikariDataSource(createLocalHikariConfig())
+
+        repo = PostgresFailedVedtaksmeldingRepository(dataSource)
+    }
+
+    @Test
+    fun `Kan lagre, hente og slette (CRuD) og etterlater ingen åpne tilkoblinger fra connectionpoolen`() {
+        repo.save(failedVedtaksmelding)
+
+        val messages = repo.getNextFailedMessages(10)
+
+        assertThat(messages.size).isEqualTo(1)
+        assertThat(messages.first()).isEqualTo(failedVedtaksmelding)
+
+        repo.delete(failedVedtaksmelding.id)
+        val empty = repo.getNextFailedMessages(10)
+        assertThat(empty.size).isEqualTo(0)
+
+        assertThat(dataSource.hikariPoolMXBean.activeConnections).isEqualTo(0)
+    }
+}

--- a/src/test/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessorTests.kt
+++ b/src/test/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingProcessorTests.kt
@@ -75,7 +75,7 @@ open class VedtaksmeldingProcessorTests {
         assertThat(saveArg.isCaptured).isTrue()
         assertThat(saveArg.captured.errorMessage).isEqualTo(message)
         assertThat(saveArg.captured.id).isNotNull()
-        assertThat(saveArg.captured.melding).isEqualTo(messageList[0])
+        assertThat(saveArg.captured.messageData).isEqualTo(messageList[0])
     }
 
     @Test


### PR DESCRIPTION
* initdb-script for å opprette tabell for feilede meldinger
* postgres repo for feilede Vedtaksmeldinger, CRuD
* Fjernet hentArbeidsgiver fra YP-repoet da det ikke trengs der