### PR TITLE
Bruk samme arbeidsgiver- og persongenerator overalt

### DIFF
--- a/src/main/kotlin/no/nav/helse/spion/domene/ArbeidsgiverGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ArbeidsgiverGenerator.kt
@@ -22,9 +22,25 @@ class ArbeidsgiverGenerator(
             arbeidsgivere.pickRandom()
         } else {
             var orgNr = Random.Default.nextLong(11111111, 99999999).toString()
-            orgNr += OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, orgNr)
+            var knrOrg = OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, orgNr)
             var virkNr = Random.Default.nextLong(11111111, 99999999).toString()
-            virkNr += OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, virkNr)
+            var knrVirk = OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, virkNr)
+
+            while(knrOrg == 10) {
+                orgNr = Random.Default.nextLong(11111111, 99999999).toString()
+                knrOrg = OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, orgNr)
+            }
+
+            while(knrVirk == 10) {
+                virkNr = Random.Default.nextLong(11111111, 99999999).toString()
+                knrVirk = OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, virkNr)
+            }
+
+            orgNr += knrOrg
+            virkNr += knrVirk
+
+
+
 
             val arbeidsGiver = Arbeidsgiver(
                     faker.funnyName().name(),

--- a/src/main/kotlin/no/nav/helse/spion/domene/ArbeidsgiverGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ArbeidsgiverGenerator.kt
@@ -1,0 +1,42 @@
+package no.nav.helse.spion.domene
+
+import com.github.javafaker.Faker
+import no.nav.helse.spion.web.dto.validation.OrganisasjonsnummerValidator
+import kotlin.random.Random
+
+class ArbeidsgiverGenerator(
+        fixedList: MutableList<Arbeidsgiver>? = null,
+        private var maxUniqueArbeidsgivere: Int = 1000) {
+
+    private val faker = Faker()
+    private val arbeidsgivere = fixedList ?: mutableListOf()
+
+    init {
+        if (fixedList != null) {
+            maxUniqueArbeidsgivere = fixedList.size
+        }
+    }
+
+    fun getRandomArbeidsGiver(): Arbeidsgiver {
+        return if (arbeidsgivere.size >= maxUniqueArbeidsgivere) {
+            arbeidsgivere.pickRandom()
+        } else {
+            var orgNr = Random.Default.nextLong(11111111, 99999999).toString()
+            orgNr += OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, orgNr)
+            var virkNr = Random.Default.nextLong(11111111, 99999999).toString()
+            virkNr += OrganisasjonsnummerValidator.checksum(OrganisasjonsnummerValidator.Companion.tabeller.weights, virkNr)
+
+            val arbeidsGiver = Arbeidsgiver(
+                    faker.funnyName().name(),
+                    orgNr,
+                    virkNr
+            )
+            arbeidsgivere.add(arbeidsGiver)
+            arbeidsGiver
+        }
+    }
+}
+
+private fun <E> List<E>.pickRandom(): E {
+    return this[Random.Default.nextInt(0, this.size)]!!
+}

--- a/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/PersonGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/domene/ytelsesperiode/PersonGenerator.kt
@@ -1,0 +1,49 @@
+package no.nav.helse.spion.domene.ytelsesperiode
+
+import com.github.javafaker.Faker
+import no.nav.helse.spion.domene.Person
+import no.nav.helse.spion.web.dto.validation.FoedselsNrValidator
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.random.Random
+
+class PersonGenerator(private val maxUniquePersons: Int = 1000) {
+    private val faker = Faker()
+    private val personer = mutableListOf<Person>()
+    fun getRandomPerson(): Person {
+        return if (personer.size >= maxUniquePersons) {
+            personer.pickRandom()
+        } else {
+            val tenYearsBeforeAfterEpoch = 3600 * 24 * 365 * 10L
+            val birthdate = LocalDate.ofInstant(Instant.ofEpochSecond(Random.nextLong(-tenYearsBeforeAfterEpoch, tenYearsBeforeAfterEpoch)), ZoneId.systemDefault())
+
+            val bday = birthdate.format(DateTimeFormatter.ofPattern("ddMMyy"))
+            var pnr = Random.nextInt(100, 999)
+            var knr1 = FoedselsNrValidator.checksum(FoedselsNrValidator.Companion.tabeller.kontrollsiffer1, bday + pnr)
+            var knr2 = FoedselsNrValidator.checksum(FoedselsNrValidator.Companion.tabeller.kontrollsiffer2, bday + pnr + knr1)
+
+            // visse kombinasjoner av tall kan gi kontrollsiffer 10 (og da et 12-sifret nummer), disse blir forkastet
+            while (knr1 == 10 || knr2 == 10) {
+                pnr = Random.nextInt(100, 999)
+                knr1 = FoedselsNrValidator.checksum(FoedselsNrValidator.Companion.tabeller.kontrollsiffer1, bday + pnr)
+                knr2 = FoedselsNrValidator.checksum(FoedselsNrValidator.Companion.tabeller.kontrollsiffer2, bday + pnr + knr1)
+            }
+
+
+            val fnr = bday + pnr + knr1 + knr2
+
+            val person = Person(
+                    faker.name().firstName(),
+                    faker.name().lastName(),
+                    fnr
+            )
+            personer.add(person)
+            person
+        }
+    }
+}
+private fun <E> List<E>.pickRandom(): E {
+    return this[Random.Default.nextInt(0, this.size)]!!
+}

--- a/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/spion/vedtaksmelding/VedtaksmeldingsGenerator.kt
@@ -1,76 +1,12 @@
 package no.nav.helse.spion.vedtaksmelding
 
-import com.github.javafaker.Faker
 import no.nav.helse.spion.domene.Arbeidsgiver
+import no.nav.helse.spion.domene.ArbeidsgiverGenerator
 import no.nav.helse.spion.domene.Periode
-import no.nav.helse.spion.domene.Person
-import no.nav.helse.spion.web.dto.validation.FoedselsNrValidator
-import no.nav.helse.spion.web.dto.validation.FoedselsNrValidator.Companion.tabeller.kontrollsiffer1
-import no.nav.helse.spion.web.dto.validation.FoedselsNrValidator.Companion.tabeller.kontrollsiffer2
-import no.nav.helse.spion.web.dto.validation.OrganisasjonsnummerValidator
-import no.nav.helse.spion.web.dto.validation.OrganisasjonsnummerValidator.Companion.tabeller.weights
-import java.time.Instant
+import no.nav.helse.spion.domene.ytelsesperiode.PersonGenerator
 import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 import kotlin.random.Random.Default.nextDouble
-import kotlin.random.Random.Default.nextInt
-import kotlin.random.Random.Default.nextLong
-
-private class ArbeidsgiverGenerator(fixedList: MutableList<Arbeidsgiver>? = null, private var maxUniqueArbeidsgivere: Int = 1000) {
-    private val faker = Faker()
-    private val arbeidsgivere = fixedList ?: mutableListOf()
-
-    init {
-        if (fixedList != null) {
-            maxUniqueArbeidsgivere = fixedList.size
-        }
-    }
-
-    fun getRandomArbeidsGiver(): Arbeidsgiver {
-        return if (arbeidsgivere.size >= maxUniqueArbeidsgivere) {
-            arbeidsgivere.pickRandom()
-        } else {
-            var orgNr = Random.Default.nextLong(11111111, 99999999).toString()
-            orgNr += OrganisasjonsnummerValidator.checksum(weights, orgNr)
-            var virkNr = Random.Default.nextLong(11111111, 99999999).toString()
-            virkNr += OrganisasjonsnummerValidator.checksum(weights, orgNr)
-
-            val arbeidsGiver = Arbeidsgiver(
-                    faker.funnyName().name(),
-                    orgNr,
-                    virkNr
-            )
-            arbeidsgivere.add(arbeidsGiver)
-            arbeidsGiver
-        }
-    }
-}
-
-class PersonGenerator(private val maxUniquePersons: Int = 1000) {
-    private val faker = Faker()
-    private val persone = mutableListOf<Person>()
-    fun getRandomPerson(): Person {
-        return if (persone.size >= maxUniquePersons) {
-            persone.pickRandom()
-        } else {
-            val tenYearsBeforeAfterEpoch = 3600 * 24 * 365 * 10L
-            val birthDay = LocalDate.ofInstant(Instant.ofEpochSecond(nextLong(-tenYearsBeforeAfterEpoch, tenYearsBeforeAfterEpoch)), ZoneId.systemDefault())
-            var fnr = birthDay.format(DateTimeFormatter.ofPattern("ddMMyy")) + nextInt(100, 999)
-            fnr += FoedselsNrValidator.checksum(kontrollsiffer1, fnr)
-            fnr += FoedselsNrValidator.checksum(kontrollsiffer2, fnr)
-
-            val person = Person(
-                    faker.name().firstName(),
-                    faker.name().lastName(),
-                    fnr
-            )
-            persone.add(person)
-            person
-        }
-    }
-}
 
 private val periodStateGenerator = {
     val rand = Random.Default.nextInt(0, 100)

--- a/src/test/kotlin/no/nav/helse/YtelsesperiodeGenerator.kt
+++ b/src/test/kotlin/no/nav/helse/YtelsesperiodeGenerator.kt
@@ -1,64 +1,15 @@
 package no.nav.helse
 
-import com.github.javafaker.Faker
 import no.nav.helse.spion.domene.Arbeidsgiver
+import no.nav.helse.spion.domene.ArbeidsgiverGenerator
 import no.nav.helse.spion.domene.Periode
-import no.nav.helse.spion.domene.Person
 import no.nav.helse.spion.domene.ytelsesperiode.Arbeidsforhold
+import no.nav.helse.spion.domene.ytelsesperiode.PersonGenerator
 import no.nav.helse.spion.domene.ytelsesperiode.Ytelsesperiode
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.*
 import kotlin.random.Random
-
-private class ArbeidsgiverGenerator(private val maxUniqueArbeidsgivere: Int = 1000, private val maxUniqueOrganisasjoner: Int = 1000) {
-    private val faker = Faker()
-    private val arbeidsgivere = mutableListOf<Arbeidsgiver>()
-    private val organisasjoner = mutableListOf<String>()
-    fun getRandomArbeidsGiver(): Arbeidsgiver {
-        return if (arbeidsgivere.size >= maxUniqueArbeidsgivere) {
-            arbeidsgivere.pickRandom()
-        } else {
-            val arbeidsGiver = Arbeidsgiver(
-                    navn = faker.funnyName().name(),
-                    organisasjonsnummer = getRandomOrganisasjonsnummer(),
-                    arbeidsgiverId = Random.Default.nextLong(111111111, 999999999).toString()
-            )
-            arbeidsgivere.add(arbeidsGiver)
-            arbeidsGiver
-        }
-    }
-
-    fun getRandomOrganisasjonsnummer(): String {
-        return if (organisasjoner.size >= maxUniqueOrganisasjoner) {
-            organisasjoner.pickRandom()
-        } else {
-            Random.Default.nextLong(111111111, 999999999).toString().let {
-                organisasjoner.add(it)
-                it
-            }
-
-        }
-    }
-}
-
-private class PersonGenerator(private val maxUniquePersons: Int = 1000) {
-    private val faker = Faker()
-    private val persone = mutableListOf<Person>()
-    fun getRandomPerson(): Person {
-        return if (persone.size >= maxUniquePersons) {
-            persone.pickRandom()
-        } else {
-            val person = Person(
-                    faker.name().firstName(),
-                    faker.name().lastName(),
-                    Random.Default.nextLong(10000000000, 31120099999).toString()
-            )
-            persone.add(person)
-            person
-        }
-    }
-}
 
 private val periodStateGenerator = {
     val rand = Random.Default.nextInt(0, 100)
@@ -71,15 +22,13 @@ private val periodStateGenerator = {
 }
 
 class YtelsesperiodeGenerator(
+        fixedListArbeidsgivere: MutableList<Arbeidsgiver>? = null,
         maxUniqueArbeidsgivere: Int,
-        maxUniqueOrganisasjoner: Int,
         maxUniquePersoner: Int,
         private val initDate: LocalDate = LocalDate.of(2020, 1, 1)
-) : Iterable<Ytelsesperiode>, Iterator<Ytelsesperiode>
+) : Iterable<Ytelsesperiode>, Iterator<Ytelsesperiode> {
 
-{
-
-    private val arbeidsgiverGenerator = ArbeidsgiverGenerator(maxUniqueArbeidsgivere, maxUniqueOrganisasjoner)
+    private val arbeidsgiverGenerator = ArbeidsgiverGenerator(fixedListArbeidsgivere,maxUniqueArbeidsgivere)
     private val personGenerator = PersonGenerator(maxUniquePersoner)
     private var numGeneratedPerioder = 0
     private val maxPeriodeLength = 31L;

--- a/src/test/kotlin/no/nav/helse/YtelsesperiodeGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/helse/YtelsesperiodeGeneratorTest.kt
@@ -1,17 +1,18 @@
 
 package no.nav.helse
+import no.nav.helse.spion.web.dto.PersonOppslagDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class YtelsesperiodeGeneratorTest {
     @Test
-    fun `Det skal komme ut data av generatoren`() {
-        val generator = YtelsesperiodeGenerator(2, 5, 10)
+    fun `Det skal komme validert testdata ut av generatoren`() {
+        val generator = YtelsesperiodeGenerator(maxUniqueArbeidsgivere = 5, maxUniquePersoner =  10)
 
         val ypl = generator
                 .take(50)
                 .toList()
-                .onEach { println(it) }
+                .onEach { PersonOppslagDto(it.arbeidsforhold.arbeidstaker.identitetsnummer, it.arbeidsforhold.arbeidsgiver.arbeidsgiverId) }
 
         assertThat(ypl).hasSize(50)
     }

--- a/src/test/kotlin/no/nav/helse/slowtests/db/integration/postgresYtelsesperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/integration/postgresYtelsesperiodeRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.zaxxer.hikari.HikariDataSource
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.helse.YtelsesperiodeGenerator
 import no.nav.helse.spion.db.createLocalHikariConfig
 import no.nav.helse.spion.domene.Arbeidsgiver
 import no.nav.helse.spion.domene.Periode

--- a/src/test/kotlin/no/nav/helse/spion/db/unit/DatabaseUnitTests.kt
+++ b/src/test/kotlin/no/nav/helse/spion/db/unit/DatabaseUnitTests.kt
@@ -66,7 +66,7 @@ internal class dbUnitTests : KoinComponent {
 
     @Test
     fun `ruller tilbake en transaksjon hvis noe feiler`() {
-        val ypGen = YtelsesperiodeGenerator(10, 10, 10)
+        val ypGen = YtelsesperiodeGenerator(maxUniqueArbeidsgivere =  10, maxUniquePersoner =  10)
         val yp = ypGen.next()
 
         every { dsMock.connection } returns conMock


### PR DESCRIPTION
- bruk samme arbeidsgiver- og persongenerator i YtelsesperiodeGenerator og VedtaksmeldingsGenerator
- bugfix: generer riktig kontrollsiffer for virksomhetsnummer
- bugfix: forkast genererte personnummer som får kontrollsiffer beregnet til 10